### PR TITLE
#56 Fix for Safari regex

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -152,7 +152,11 @@ export const errorMessage = (err: unknown) => (err as Error).message
 const extractNumber = (input: EvaluatorOutput) => {
   if (typeof input !== 'string') return Number.isNaN(Number(input)) ? input : Number(input)
 
-  const numberMatch = input.match(/(-?(\d+\.\d+))|(-?((?<!\.)\.\d+))|(-?\d+)/gm)
+  // Optional negative sign, optional digit, optional decimal point, then 1 or
+  // more digits
+  const pattern = new RegExp(/-?\d?\.?\d+/gm)
+
+  const numberMatch = input.match(pattern)
   if (!numberMatch) return 0
   return Number(numberMatch[0])
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -152,9 +152,9 @@ export const errorMessage = (err: unknown) => (err as Error).message
 const extractNumber = (input: EvaluatorOutput) => {
   if (typeof input !== 'string') return Number.isNaN(Number(input)) ? input : Number(input)
 
-  // Optional negative sign, optional digit, optional decimal point, then 1 or
-  // more digits
-  const pattern = new RegExp(/-?\d?\.?\d+/gm)
+  // Optional negative sign, optional digit(s), optional decimal point, then 1
+  // or more digits
+  const pattern = new RegExp(/-?\d*\.?\d+/gm)
 
   const numberMatch = input.match(pattern)
   if (!numberMatch) return 0


### PR DESCRIPTION
Simplified the regex to not use lookahead/lookbehind, which allows it to work in Safari.