### PR TITLE
113 Error handling improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1868,16 +1868,17 @@ Operator: <OPERATOR_NAME>: - <error.name (if specific)>
 ```
 `errorData` is specific data returned by the error thrown by an internal process (such as a network request using [fetch](#http-requests)).
 
-For example, a failed login using the `POST` operator (with Axios HTTP client) would return a string like:
+For example, a 403 (forbidden) error thrown by the `GET` operator (with Axios HTTP client) would return a string like:
 ```
-Operator: POST - AxiosError
-Request failed with status code 400
+Operator: GET - AxiosError
+Request failed with status code 403
 {
-  "status": 400,
-  "error": "Bad Request",
-  "url": "https://reqres.in/api/login",
+  "status": 403,
+  "error": "Forbidden",
+  "url": "http://httpstat.us/403",
   "response": {
-    "error": "Missing password"
+    "success": false,
+    "message": "jwt must be provided"
   }
 }
 ```
@@ -1886,20 +1887,22 @@ And, if thrown, the error object would contain:
 ```js
 {
   name: "AxiosError",
-  message: "Request failed with status code 400"
-  operator: "POST",
+  message: "Request failed with status code 403"
+  operator: "GET",
   errorData: {
-      status: 400,
-      error: 'Bad Request',
-      url: 'https://reqres.in/api/login',
-      response: { error: 'Missing password' }
+      status: 403,
+      error: 'Forbidden',
+      url: 'http://httpstat.us/403',
+      response: {
+        success: false,
+        message: "jwt must be provided"
+      }
     }
   expression: {
-      operator: 'POST',
-      url: 'https://reqres.in/api/login',
-      parameters: { email: 'eve.holt@reqres.in' }
+      operator: 'API',
+      url: 'http://httpstat.us/403',
     }
-  ...otherProperties // all AxiosError and standard Error properties
+    ...otherProperties // all AxiosError and standard Error properties
 }
 ```
 
@@ -1911,9 +1914,9 @@ Evaluator expressions can be configured by hand, with [aliases](#alias-nodes), [
 
 However, you may wish to build an external UI for building FigTree expression. To this end, the FigTree instance provides three methods that could be useful for populating your configuration UI:
 
-#### New FigTree instance
+#### A new FigTree instance:
 
-Containing fragments and [custom functions](#custom_functions).
+- containing fragments and [custom functions](#custom_functions).
 
 ```js
 const fig = new FigTreeEvaluator({

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A range of built-in operators are available, from simple logic, arithmetic and s
 - [Fragments](#fragments)
 - [Shorthand syntax](#shorthand-syntax)
 - [Caching (Memoization)](#caching-memoization)
+- [Error handling](#error-handling)
 - [Metadata](#metadata)
 - [More examples](#more-examples)
 - [Development environment](#development-environment)
@@ -156,7 +157,7 @@ The `options` parameter is an object with the following available properties (al
 - `sqlConnection` -- if you wish to make calls to an SQL database using the [`SQL` operator](#sql), pass a connection to the database here. See operator details below.
 - `baseEndpoint` -- A general http headers object that will be passed to *all* http-based operators (`GET`, `POST`, `GraphQL`). Useful if all http queries are to a common server -- then each individual node will only require a relative url. See specific operator for more details.
 - `headers` -- A general http headers object that will be passed to *all* http-based operators. Useful for authentication headers, for example. Each operator and instance can have its own headers, though, so see specific operator reference for details.
-- `returnErrorAsString` -- by default the evaluator will throw errors with invalid evaluation expressions (with helpful error messages indicating the node which threw the error and what the problem was). But if you have `returnErrorAsString: true` set, the evaluator will never throw, but instead return error messages as a valid string output. (See also the [`fallback`](#other-common-properties) parameter below)
+- `returnErrorAsString` -- by default the evaluator will throw errors with invalid evaluation expressions (with helpful error messages indicating the node which threw the error and what the problem was). But if you have `returnErrorAsString: true` set, the evaluator will never throw, but instead return error messages as a valid string output. (See also the [`fallback`](#other-common-properties) parameter below). See [Error handling](#error-handling) section for more detail.
 - `allowJSONStringInput` -- the evaluator is expecting the input expression to be a javascript object. However, it will also accept JSON strings if this option is set to `true`. We have to perform additional logic on every evaluation input to determine if a string is a JSON expression or a standard string, so this is skipped by default for performance reasons. However, if you want to send (for example) user input directly to the evaluator without running it through your own `JSON.parse()`, then enable this option.
 - `skipRuntimeTypeCheck` -- we perform comprehensive type checking at runtime to ensure that each operator only performs its operation on valid inputs. If type checking fails, we throw an error detailing the explicit problem. However, if `skipRuntimeTypeCheck` is set to `true`, then all inputs are passed to the operator regardless, and any errors will come from whatever standard javascript errors might be encountered (e.g. trying to pass a primitive value when an array is expected => `.map is not a function`)
 - `caseInsensitive` -- this only affects the [`equal`/`notEqual` operators](#equal) (see there for more detail). 
@@ -226,7 +227,8 @@ Most of the time named properties would be preferable; however there are occasio
 
 In each operator node, as well as the operator-specific properties, the following three optional properties can be provided:
 
-- `fallback`: if the operation throws an error, the `fallback` value will be returned instead. The `fallback` property can be provided at any level of the expression tree and bubbled up from where errors are caught to parent nodes. *Fallbacks are strongly recommended if there is any chance of an error (e.g. a network "GET" request that doesn't yet have its parameters defined).*
+- `fallback`: if the operation throws an error, the `fallback` value will be returned instead. The `fallback` property can be provided at any level of the expression tree and bubbled up from where errors are caught to parent nodes. *Fallbacks are strongly recommended if there is any chance of an error (e.g. a network "GET" request that doesn't yet have its parameters defined).*  
+See [Error handling](#error-handling)
 - `outputType` (or `type`): will convert the result of the current node to the specified `outputType`. Valid values are `string`, `number`, `boolean` (or `bool`), and `array`. You can experiment in the [demo app](https://carlosnz.github.io/fig-tree-evaluator/) to see the outcome of applying different `outputType` values to various results.
 - `useCache`: Overrides the global `useCache` value (from [options](#available-options)) for this node only. See [Caching/Memoization](#caching-memoization) below for more info.
 
@@ -1840,6 +1842,68 @@ fig.getCache() // returns key-value store
 fig.setCache(cache) // where "cache" is the object retrieved by .getCache()
 ```
 
+## Error handling
+
+By default, FigTree will throw errors that can be caught and handled by your application. The Error object is a `FigTreeError`, which extends the standard `Error` object (with `name` and `message` fields) with the following interface:
+
+```ts
+interface FigTreeError extends Error {
+  errorData?: Record<string, unknown>
+  operator?: Operator
+  expression?: EvaluatorNode
+}
+```
+
+There are two alternatives to throwing:
+
+1. **Fallback**: If the `fallback` property is specified in the expression, this will be returned whenever an error occurs at that node (or below). See [Fallback option](#other-common-properties).
+2. **Formatted string**: By using the `returnErrorAsString: true` option, FigTree will return a nicely formatted string describing the error. The formatted string will be structured like so:
+
+```
+Operator: <OPERATOR_NAME>: - <error.name (if specific)>
+<error.message>
+{
+  ...errorData
+}
+```
+`errorData` is specific data returned by the error thrown by an internal process (such as a network request using [fetch](#http-requests)).
+
+For example, a failed login using the `POST` operator (with Axios HTTP client) would return a string like:
+```
+Operator: POST - AxiosError
+Request failed with status code 400
+{
+  "status": 400,
+  "error": "Bad Request",
+  "url": "https://reqres.in/api/login",
+  "response": {
+    "error": "Missing password"
+  }
+}
+```
+
+And, if thrown, the error object would contain:
+```js
+{
+  name: "AxiosError",
+  message: "Request failed with status code 400"
+  operator: "POST",
+  errorData: {
+      status: 400,
+      error: 'Bad Request',
+      url: 'https://reqres.in/api/login',
+      response: { error: 'Missing password' }
+    }
+  expression: {
+      operator: 'POST',
+      url: 'https://reqres.in/api/login',
+      parameters: { email: 'eve.holt@reqres.in' }
+    }
+  ...otherProperties // all AxiosError and standard Error properties
+}
+```
+
+If extending FigTree with additional [HTTP Client](#http-requests) or [SQL Connection](#connecting-to-the-database) interfaces, please aim to adhere to this structure when throwing errors.
 
 ## Metadata
 

--- a/src/FigTreeEvaluator.ts
+++ b/src/FigTreeEvaluator.ts
@@ -47,7 +47,10 @@ class FigTreeEvaluator {
       args.length === 1 && Array.isArray(args[0]) ? args[0] : (args as TypeCheckInput[])
     const result = typeCheck(...inputArgs)
     if (result === true) return
-    throw new Error(result)
+
+    const err = new Error(result)
+    err.name = 'Type Error'
+    throw err
   }
 
   public async evaluate(expression: EvaluatorNode, options: FigTreeOptions = {}) {

--- a/src/databaseConnections.ts
+++ b/src/databaseConnections.ts
@@ -21,7 +21,6 @@ export const SQLNodePostgres = (client: Client) => {
 
     try {
       const res: QueryResult & { error?: string } = await client.query(pgQuery)
-      // node-postgres doesn't throw, it just returns error object
       if (res?.error) throw new Error(res.error)
 
       return res.rows

--- a/src/databaseConnections.ts
+++ b/src/databaseConnections.ts
@@ -4,8 +4,8 @@
 
 import { Client, QueryResult } from 'pg'
 import { QueryInput, QueryOutput } from './operators'
-
 import { Database } from 'sqlite'
+import { FigTreeError } from './types'
 
 /**
  * Postgres (using node-postgres)
@@ -19,11 +19,16 @@ export const SQLNodePostgres = (client: Client) => {
       values: (string | number | boolean)[]
     }
 
-    const res: QueryResult & { error?: string } = await client.query(pgQuery)
-    // node-postgres doesn't throw, it just returns error object
-    if (res?.error) throw new Error(res.error)
+    try {
+      const res: QueryResult & { error?: string } = await client.query(pgQuery)
+      // node-postgres doesn't throw, it just returns error object
+      if (res?.error) throw new Error(res.error)
 
-    return res.rows
+      return res.rows
+    } catch (err) {
+      ;(err as FigTreeError).name = 'Node-Postgres error'
+      throw err
+    }
   }
 
   return { query }
@@ -40,7 +45,8 @@ export const SQLite = (db: Database) => {
       const result = await db.all(query, values)
       return result
     } catch (err) {
-      throw `SQLite error: ${(err as any)?.message}`
+      ;(err as FigTreeError).name = 'SQLite error'
+      throw err
     }
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -66,9 +66,9 @@ export const truncateString = (string: string, length = 200) =>
   string.length < length ? string : `${string.slice(0, length - 2).trim()}...`
 
 /*
-Will throw an error (with `errorMessage`) if no `fallback` is provided. If
+Will throw an error (FigTreeError) if no `fallback` is provided. If
 `returnErrorAsString` is enabled, then it won't throw, but instead return a
-string containing the error message. 
+string containing a formatted error message. 
 */
 interface ErrorInput {
   fallback?: EvaluatorOutput

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -91,8 +91,8 @@ export const fallbackOrError = ({
   const err: FigTreeError = typeof error === 'string' ? new Error(error) : error
   if (name) err.name = name
   if (err.name === 'Error') err.name = 'FigTreeError'
-  err.expression = expression
-  err.operator = operator
+  err.expression = err.expression ?? expression
+  err.operator = err.operator ?? operator
 
   if (!returnErrorAsString) throw err
 
@@ -101,7 +101,9 @@ export const fallbackOrError = ({
   const topLine = operatorText + nameText
   const extraData = err.errorData ? '\n' + JSON.stringify(err.errorData, null, 2) : ''
 
-  return `${topLine !== '' ? topLine + '\n' : ''}${err.message}${extraData}`
+  return `${topLine !== '' ? topLine + '\n' : ''}${truncateString(err.message)}${
+    extraData === '\n{}' ? '' : extraData
+  }`
 }
 
 /*

--- a/src/httpClients.ts
+++ b/src/httpClients.ts
@@ -53,10 +53,11 @@ export const AxiosClient = (axios: AxiosStatic) => {
   }
 
   const throwError = (err: unknown) => {
-    if (axios.isAxiosError(err)) {
+    if (axios.isAxiosError(err) && err.response) {
       ;(err as FigTreeError).errorData = {
         status: err.response?.status,
         error: err.response?.statusText,
+        url: err.config?.url,
         response: err.response?.data,
       }
       console.log((err as FigTreeError).errorData)
@@ -87,6 +88,7 @@ export const FetchClient = (fetch: Fetch) => {
       err.errorData = {
         status: response.status,
         error: response.statusText,
+        url: response.url,
         response: json,
       }
       console.log(err.errorData)
@@ -111,6 +113,7 @@ export const FetchClient = (fetch: Fetch) => {
       err.errorData = {
         status: response.status,
         error: response.statusText,
+        url: response.url,
         response: json,
       }
       console.log(err.errorData)

--- a/src/operators/REGEX/operator.ts
+++ b/src/operators/REGEX/operator.ts
@@ -1,6 +1,5 @@
 import { getTypeCheckInput } from '../operatorUtils'
 import { evaluateArray } from '../../evaluate'
-import { errorMessage } from '../../helpers'
 import { EvaluatorNode, OperatorObject, EvaluateMethod, ParseChildrenMethod } from '../../types'
 import operatorData, { propertyAliases } from './data'
 
@@ -12,12 +11,8 @@ const evaluate: EvaluateMethod = async (expression, config) => {
 
   config.typeChecker(getTypeCheckInput(operatorData.parameters, { testString, pattern }))
 
-  try {
-    const re = new RegExp(pattern)
-    return re.test(testString)
-  } catch (err) {
-    throw new Error('Regex error:' + errorMessage(err))
-  }
+  const re = new RegExp(pattern)
+  return re.test(testString)
 }
 
 const parseChildren: ParseChildrenMethod = (expression) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,3 +168,9 @@ export type OperatorMetadata = OperatorData & {
 export type FragmentMetadata = FragmentData & { name: string }
 
 export type CustomFunctionMetadata = { name: string; numRequiredArgs: number }
+
+export interface FigTreeError extends Error {
+  errorData?: Record<string, unknown>
+  operator?: Operator
+  expression?: EvaluatorNode
+}

--- a/test/10_API.test.ts
+++ b/test/10_API.test.ts
@@ -397,10 +397,26 @@ test.concurrent('POST: Unsuccessful login, using properties', async () => {
     parameters: { email: 'eve.holt@reqres.in' },
   }
   const result = await exp.evaluate(expression)
-  expect(result).toBe('Operator: POST\nRequest failed with status code 400')
+  expect(result).toBe(`Operator: POST - AxiosError
+Request failed with status code 400
+{
+  "status": 400,
+  "error": "Bad Request",
+  "response": {
+    "error": "Missing password"
+  }
+}`)
 
   const resultFetch = await expFetch.evaluate(expression)
-  expect(resultFetch).toBe('Operator: POST\nRequest failed with status code 400')
+  expect(resultFetch).toBe(`Operator: POST - FetchError
+Problem with POST request
+{
+  "status": 400,
+  "error": "Bad Request",
+  "response": {
+    "error": "Missing password"
+  }
+}`)
 })
 
 test.concurrent('POST: Successful login, using parameters from (nested) buildObject', async () => {
@@ -430,10 +446,28 @@ test.concurrent('GET: 403 error', async () => {
     url: 'http://httpstat.us/403',
   }
   const result = await exp.evaluate(expression)
-  expect(result).toBe('Operator: GET\nRequest failed with status code 403')
+  expect(result).toBe(`Operator: GET - AxiosError
+Request failed with status code 403
+{
+  "status": 403,
+  "error": "Forbidden",
+  "response": {
+    "code": 403,
+    "description": "Forbidden"
+  }
+}`)
 
   const resultFetch = await expFetch.evaluate(expression)
-  expect(resultFetch).toBe('Operator: GET\nRequest failed with status code 403')
+  expect(resultFetch).toBe(`Operator: GET - FetchError
+Problem with GET request
+{
+  "status": 403,
+  "error": "Forbidden",
+  "response": {
+    "code": 403,
+    "description": "Forbidden"
+  }
+}`)
 })
 
 test.concurrent('GET: 404 error', async () => {
@@ -442,10 +476,28 @@ test.concurrent('GET: 404 error', async () => {
     url: 'http://httpstat.us/404',
   }
   const result = await exp.evaluate(expression)
-  expect(result).toBe('Operator: GET\nRequest failed with status code 404')
+  expect(result).toBe(`Operator: GET - AxiosError
+Request failed with status code 404
+{
+  "status": 404,
+  "error": "Not Found",
+  "response": {
+    "code": 404,
+    "description": "Not Found"
+  }
+}`)
 
   const resultFetch = await expFetch.evaluate(expression)
-  expect(resultFetch).toBe('Operator: GET\nRequest failed with status code 404')
+  expect(resultFetch).toBe(`Operator: GET - FetchError
+Problem with GET request
+{
+  "status": 404,
+  "error": "Not Found",
+  "response": {
+    "code": 404,
+    "description": "Not Found"
+  }
+}`)
 })
 
 test.concurrent('GET: 429 Error with fallback', async () => {
@@ -480,6 +532,7 @@ test.concurrent('GET: Bad url', async () => {
 
 test('GET: Fetch a country with params, using props', async () => {
   exp.updateOptions({ baseEndpoint: 'https://restcountries.com/' })
+  expFetch.updateOptions({ baseEndpoint: 'https://restcountries.com/' })
   const expression = {
     operator: 'get',
     endpoint: { operator: '+', values: ['/v3.1/name/', 'india'] },

--- a/test/10_API.test.ts
+++ b/test/10_API.test.ts
@@ -402,6 +402,7 @@ Request failed with status code 400
 {
   "status": 400,
   "error": "Bad Request",
+  "url": "https://reqres.in/api/login",
   "response": {
     "error": "Missing password"
   }
@@ -413,6 +414,7 @@ Problem with POST request
 {
   "status": 400,
   "error": "Bad Request",
+  "url": "https://reqres.in/api/login",
   "response": {
     "error": "Missing password"
   }
@@ -451,6 +453,7 @@ Request failed with status code 403
 {
   "status": 403,
   "error": "Forbidden",
+  "url": "http://httpstat.us/403",
   "response": {
     "code": 403,
     "description": "Forbidden"
@@ -463,6 +466,7 @@ Problem with GET request
 {
   "status": 403,
   "error": "Forbidden",
+  "url": "http://httpstat.us/403",
   "response": {
     "code": 403,
     "description": "Forbidden"
@@ -481,6 +485,7 @@ Request failed with status code 404
 {
   "status": 404,
   "error": "Not Found",
+  "url": "http://httpstat.us/404",
   "response": {
     "code": 404,
     "description": "Not Found"
@@ -493,6 +498,7 @@ Problem with GET request
 {
   "status": 404,
   "error": "Not Found",
+  "url": "http://httpstat.us/404",
   "response": {
     "code": 404,
     "description": "Not Found"
@@ -519,12 +525,14 @@ test.concurrent('GET: Bad url', async () => {
     url: 'http://there-is-no-f-ing-site.com',
   }
   const result = await exp.evaluate(expression)
-  expect(result).toBe('Operator: GET\nNetwork Error')
+  expect(result).toBe(
+    'Operator: GET\nNetwork error: getaddrinfo ENOTFOUND there-is-no-f-ing-site.com'
+  )
 
   const resultFetch = await expFetch.evaluate(expression)
   // This is different in browser vs node-fetch
   expect(resultFetch).toBe(
-    'Operator: GET\nrequest to http://there-is-no-f-ing-site.com/ failed, reason: getaddrinfo ENOTFOUND there-is-no-f-ing-site.com'
+    'Operator: GET - FetchError\nrequest to http://there-is-no-f-ing-site.com/ failed, reason: getaddrinfo ENOTFOUND there-is-no-f-ing-site.com'
   )
 })
 

--- a/test/12_database.test.ts
+++ b/test/12_database.test.ts
@@ -8,6 +8,7 @@ import { open, Database } from 'sqlite'
 import { AxiosClient, FetchClient } from '../src'
 import axios from 'axios'
 import fetch from 'node-fetch'
+import { FigTreeError } from '../src/types'
 
 // SQL tests require a copy of the Northwind database to be running
 // locally, with configuration defined in ./database/pgConfig.json. Initialise
@@ -311,6 +312,32 @@ test('Postgres - test single and flattening with single result record', async ()
   expect(result4).toStrictEqual([6, 'DHL', '1-800-225-5345'])
 })
 
+test('Postgres - database error', async () => {
+  const expression = {
+    operator: 'sql',
+    children: ['SELECT * FROM employee_table'],
+    type: 'number',
+  }
+  await expect(exp.evaluate(expression)).rejects.toThrow('relation "employee_table" does not exist')
+
+  const result = await exp.evaluate(expression, { returnErrorAsString: true })
+  expect(result).toBe(
+    'Operator: SQL - Node-Postgres error\nrelation "employee_table" does not exist'
+  )
+
+  try {
+    await exp.evaluate(expression)
+  } catch (err) {
+    expect((err as FigTreeError).operator).toBe('SQL')
+    expect((err as FigTreeError).expression).toStrictEqual({
+      operator: 'sql',
+      type: 'number',
+      query: 'SELECT * FROM employee_table',
+      values: [],
+    })
+  }
+})
+
 // SQLite
 
 test('SQLite - lookup single string', async () => {
@@ -511,6 +538,32 @@ test('SQLite - test single and flattening with single result record', async () =
   }
   const result4 = await expSqlite.evaluate(expression4)
   expect(result4).toMatchObject([6, 'DHL', '1-800-225-5345'])
+})
+
+test('SQLite - database error', async () => {
+  const expression = {
+    operator: 'sql',
+    children: ['SELECT * FROM employee_table'],
+    type: 'number',
+  }
+  await expect(expSqlite.evaluate(expression)).rejects.toThrow(
+    'SQLITE_ERROR: no such table: employee_table'
+  )
+
+  const result = await expSqlite.evaluate(expression, { returnErrorAsString: true })
+  expect(result).toBe('Operator: SQL - SQLite error\nSQLITE_ERROR: no such table: employee_table')
+
+  try {
+    await expSqlite.evaluate(expression)
+  } catch (err) {
+    expect((err as FigTreeError).operator).toBe('SQL')
+    expect((err as FigTreeError).expression).toStrictEqual({
+      operator: 'sql',
+      type: 'number',
+      query: 'SELECT * FROM employee_table',
+      values: [],
+    })
+  }
 })
 
 // GraphQL

--- a/test/14_buildObject.test.ts
+++ b/test/14_buildObject.test.ts
@@ -83,7 +83,7 @@ test('buildObject - missing properties', () => {
   const expression = { operator: 'buildObject' }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
     expect(result).toBe(
-      'Operator: BUILD_OBJECT\n- Missing required property "properties" (type: array)'
+      'Operator: BUILD_OBJECT - Type Error\n- Missing required property "properties" (type: array)'
     )
   })
 })
@@ -95,7 +95,7 @@ test('buildObject - invalid key type', () => {
   }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
     expect(result).toBe(
-      'Operator: BUILD_OBJECT\n- Property "key" (value: [1,2]) is not of type: string|number|boolean'
+      'Operator: BUILD_OBJECT - Type Error\n- Property "key" (value: [1,2]) is not of type: string|number|boolean'
     )
   })
 })

--- a/test/15_errorsAndFallbacks.test.ts
+++ b/test/15_errorsAndFallbacks.test.ts
@@ -373,7 +373,9 @@ test('GET - 404 error', async () => {
     operator: 'get',
     url: 'http://httpstat.us/404',
   }
-  await expect(exp.evaluate(expression)).rejects.toThrow('Problem with GET request')
+  await expect(exp.evaluate(expression, { httpClient: fetch })).rejects.toThrow(
+    'Problem with GET request'
+  )
   await expect(exp.evaluate(expression, { httpClient: axios })).rejects.toThrow(
     'Request failed with status code 404'
   )

--- a/test/15_errorsAndFallbacks.test.ts
+++ b/test/15_errorsAndFallbacks.test.ts
@@ -1,4 +1,7 @@
+import fetch from 'node-fetch'
 import { FigTreeEvaluator, evaluateExpression } from './evaluator'
+import axios from 'axios'
+import { FigTreeError } from '../src/types'
 
 const exp = new FigTreeEvaluator({
   objects: {
@@ -15,6 +18,7 @@ const exp = new FigTreeEvaluator({
       questions: { q1: 'What is the answer?', q2: 'Enter your name' },
     },
   },
+  httpClient: fetch,
   nullEqualsUndefined: true,
 })
 
@@ -44,7 +48,7 @@ test('ERROR - Invalid/Missing children error', async () => {
     children: 2,
   }
   await expect(evaluateExpression(expression)).rejects.toThrow(
-    'Operator: OR\n- Property "children" is not of type: array'
+    'Property "children" is not of type: array'
   )
 })
 
@@ -54,7 +58,7 @@ test('ERROR as string - Invalid/Missing children', () => {
     children: 2,
   }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
-    expect(result).toBe('Operator: OR\n- Property "children" is not of type: array')
+    expect(result).toBe('Operator: OR - Type Error\n- Property "children" is not of type: array')
   })
 })
 
@@ -65,7 +69,7 @@ test('ERROR - Invalid output type', async () => {
     type: 'Integer',
   }
   await expect(evaluateExpression(expression)).rejects.toThrow(
-    'Operator: PLUS\n- Property "type" (value: "Integer") is not of type: Literal("string", "array", "number", "boolean", "bool", undefined)'
+    'Property "type" (value: "Integer") is not of type: Literal("string", "array", "number", "boolean", "bool", undefined)'
   )
 })
 
@@ -76,7 +80,7 @@ test('OR - Error', async () => {
     operator: 'OR',
   }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: OR\n- Missing required property "values" (type: array)'
+    'Missing required property "values" (type: array)'
   )
 })
 
@@ -85,7 +89,9 @@ test('OR - Error as string', () => {
     operator: 'OR',
   }
   return evaluateExpression(expression, { returnErrorAsString: true }).then((result) => {
-    expect(result).toBe('Operator: OR\n- Missing required property "values" (type: array)')
+    expect(result).toBe(
+      'Operator: OR - Type Error\n- Missing required property "values" (type: array)'
+    )
   })
 })
 
@@ -104,7 +110,7 @@ test('AND - Error', async () => {
     operator: 'AND',
   }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: AND\n- Missing required property "values" (type: array)'
+    'Missing required property "values" (type: array)'
   )
 })
 
@@ -113,7 +119,9 @@ test('AND - Error as string', () => {
     operator: 'And',
   }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
-    expect(result).toBe('Operator: AND\n- Missing required property "values" (type: array)')
+    expect(result).toBe(
+      'Operator: AND - Type Error\n- Missing required property "values" (type: array)'
+    )
   })
 })
 
@@ -134,7 +142,7 @@ test('REGEX - Error', async () => {
     testString: 'anything',
   }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: REGEX\n- Property "pattern" (value: {"one":1}) is not of type: string'
+    'Property "pattern" (value: {"one":1}) is not of type: string'
   )
 })
 
@@ -178,8 +186,19 @@ test('ERROR - bubble up from nested', async () => {
     ],
   }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: REGEX\n- Property "pattern" (value: {"one":1}) is not of type: string'
+    'Property "pattern" (value: {"one":1}) is not of type: string'
   )
+  try {
+    await exp.evaluate(expression)
+  } catch (err) {
+    // Check error object data is as expected
+    expect((err as FigTreeError).operator).toBe('REGEX')
+    expect((err as FigTreeError).expression).toStrictEqual({
+      operator: 'regex',
+      pattern: { one: 1 },
+      testString: 'anything',
+    })
+  }
 })
 
 // Fallback bubbles up from nested
@@ -204,6 +223,7 @@ test('FALLBACK - multiple bubble up and join', () => {
       },
     ],
   }
+
   return evaluateExpression(expression).then((result) => {
     expect(result).toBe('First Error / Second Error')
   })
@@ -272,7 +292,7 @@ test('Skip runtime type checking, from current options', () => {
     })
     .then((result) => {
       expect(result).toBe(
-        'Operator: OBJECT_PROPERTIES\nUnable to extract object property\nLooking for property: not\nIn object: {"user":"Unknown","organisation":{"id":1,"name":"The Avengers","category":"Superheroes"},"form":{"q...'
+        'Operator: OBJECT_PROPERTIES\nUnable to extract object property\nLooking for property: not\nIn object: {"user":"Unknown","organisation":{"id":1,"name":"The Avengers","category":"Superheroes"},"form":{"q1":"Thor","q2":"Asgard"},"fo...'
       )
     })
 })
@@ -295,4 +315,55 @@ test('Skip runtime type checking, from constructor options', () => {
         'Operator: OBJECT_PROPERTIES\nUnable to extract object property\nLooking for property: not\nIn object: {"user":"Unknown"}'
       )
     })
+})
+
+// API and Database errors
+
+test('GET - 404 error', async () => {
+  const expression = {
+    operator: 'get',
+    url: 'http://httpstat.us/404',
+  }
+  await expect(exp.evaluate(expression)).rejects.toThrow('Problem with GET request')
+  await expect(exp.evaluate(expression, { httpClient: axios })).rejects.toThrow(
+    'Request failed with status code 404'
+  )
+  try {
+    await exp.evaluate(expression)
+  } catch (err: any) {
+    expect(err.operator).toBe('GET')
+  }
+})
+
+test('POST - Bad login', async () => {
+  const expAxios = new FigTreeEvaluator({
+    httpClient: axios,
+  })
+  const expression = {
+    operator: 'POST',
+    url: 'https://reqres.in/api/login',
+    parameters: { email: 'eve.holt@reqres.in' },
+  }
+  await expect(expAxios.evaluate(expression)).rejects.toThrow('Request failed with status code 400')
+  await expect(expAxios.evaluate(expression, { httpClient: fetch })).rejects.toThrow(
+    'Problem with POST request'
+  )
+  try {
+    await exp.evaluate(expression)
+  } catch (err) {
+    expect((err as FigTreeError).operator).toBe('POST')
+    expect((err as FigTreeError).expression).toStrictEqual({
+      operator: 'POST',
+      url: 'https://reqres.in/api/login',
+      parameters: { email: 'eve.holt@reqres.in' },
+    })
+    expect((err as FigTreeError).errorData).toStrictEqual({
+      status: 400,
+      error: 'Bad Request',
+      url: 'https://reqres.in/api/login',
+      response: {
+        error: 'Missing password',
+      },
+    })
+  }
 })

--- a/test/15_errorsAndFallbacks.test.ts
+++ b/test/15_errorsAndFallbacks.test.ts
@@ -330,8 +330,8 @@ test('GET - 404 error', async () => {
   )
   try {
     await exp.evaluate(expression)
-  } catch (err: any) {
-    expect(err.operator).toBe('GET')
+  } catch (err) {
+    expect((err as FigTreeError).operator).toBe('GET')
   }
 })
 
@@ -365,5 +365,21 @@ test('POST - Bad login', async () => {
         error: 'Missing password',
       },
     })
+  }
+})
+
+test('GET - 404 error', async () => {
+  const expression = {
+    operator: 'get',
+    url: 'http://httpstat.us/404',
+  }
+  await expect(exp.evaluate(expression)).rejects.toThrow('Problem with GET request')
+  await expect(exp.evaluate(expression, { httpClient: axios })).rejects.toThrow(
+    'Request failed with status code 404'
+  )
+  try {
+    await exp.evaluate(expression)
+  } catch (err: any) {
+    expect(err.operator).toBe('GET')
   }
 })

--- a/test/17_complexExpressions.test.ts
+++ b/test/17_complexExpressions.test.ts
@@ -93,7 +93,7 @@ test('"children" is an evaluator expression but doesn\'t return an array', () =>
     })
     .then((result) => {
       expect(result).toStrictEqual(
-        'Operator: OBJECT_PROPERTIES\n- Property "children" is not of type: array'
+        'Operator: OBJECT_PROPERTIES - Type Error\n- Property "children" is not of type: array'
       )
     })
 })

--- a/test/18_optionHandling.test.ts
+++ b/test/18_optionHandling.test.ts
@@ -77,9 +77,7 @@ test('Operator exclusion: update options later', async () => {
     values: [{ operator: 'subtract', values: [10, 3] }, 10],
   }
   figTree.updateOptions({ excludeOperators: ['-'] })
-  await expect(figTree.evaluate(expression)).rejects.toThrow(
-    'Operator: PLUS\nExcluded operator: subtract'
-  )
+  await expect(figTree.evaluate(expression)).rejects.toThrow('Excluded operator: subtract')
 })
 
 test('Operator exclusion: update options later -- previous exclusions are restored', async () => {

--- a/test/3_equality.test.ts
+++ b/test/3_equality.test.ts
@@ -221,7 +221,7 @@ test('Equality (arrays, not matching)', () => {
 test('Equality -- missing values', async () => {
   const expression = { operator: '=' }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: EQUAL\n- Missing required property "values" (type: array)'
+    '- Missing required property "values" (type: array)'
   )
 })
 
@@ -341,6 +341,6 @@ test('Inequality (only one value)', () => {
 test('Inequality -- missing values', async () => {
   const expression = { operator: '!=' }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: NOT_EQUAL\n- Missing required property "values" (type: array)'
+    '- Missing required property "values" (type: array)'
   )
 })

--- a/test/4_plus.test.ts
+++ b/test/4_plus.test.ts
@@ -118,7 +118,9 @@ test('Merge 3 objects', () => {
 test('Missing values', () => {
   const expression = { operator: '+' }
   return exp.evaluate(expression).then((result) => {
-    expect(result).toBe('Operator: PLUS\n- Missing required property "values" (type: array)')
+    expect(result).toBe(
+      'Operator: PLUS - Type Error\n- Missing required property "values" (type: array)'
+    )
   })
 })
 

--- a/test/5_otherArithmetic.test.ts
+++ b/test/5_otherArithmetic.test.ts
@@ -57,9 +57,7 @@ test('MINUS operator with one NaN operand', () => {
 
 test('MINUS operator with not enough values', async () => {
   const expression = { operator: '-', values: [0.3] }
-  await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: SUBTRACT\n- Not enough values provided'
-  )
+  await expect(exp.evaluate(expression)).rejects.toThrow('- Not enough values provided')
 })
 
 test('MINUS operator with missing "from" property', () => {
@@ -114,7 +112,9 @@ test('MULTIPLY operator with non-number inputs', () => {
 test('MULTIPLY - Missing values', () => {
   const expression = { operator: '*' }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
-    expect(result).toBe('Operator: MULTIPLY\n- Missing required property "values" (type: array)')
+    expect(result).toBe(
+      'Operator: MULTIPLY - Type Error\n- Missing required property "values" (type: array)'
+    )
   })
 })
 
@@ -189,9 +189,7 @@ test('DIVIDE operator with one NaN operand', () => {
 
 test('DIVIDE operator with not enough values', async () => {
   const expression = { operator: '/', children: [99] }
-  await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: DIVIDE\n- Not enough values provided'
-  )
+  await expect(exp.evaluate(expression)).rejects.toThrow('- Not enough values provided')
 })
 
 test('DIVIDE operator with Evaluator node values', () => {
@@ -256,15 +254,13 @@ test('Greater than - equal vals, non-strict strings', () => {
 test('Greater than - missing values', async () => {
   const expression = { operator: '>' }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: GREATER_THAN\n- Missing required property "values" (type: array)'
+    '- Missing required property "values" (type: array)'
   )
 })
 
 test('Greater than - not enough values', async () => {
   const expression = { operator: '>', values: [12] }
-  await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: GREATER_THAN\n- Not enough values provided'
-  )
+  await expect(exp.evaluate(expression)).rejects.toThrow('- Not enough values provided')
 })
 
 test('Less than - integer comparison', () => {
@@ -316,7 +312,7 @@ test('Less than - equal vals, non-strict strings', () => {
 test('Less than - missing values', async () => {
   const expression = { operator: '<' }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: LESS_THAN\n- Missing required property "values" (type: array)'
+    '- Missing required property "values" (type: array)'
   )
 })
 
@@ -359,7 +355,7 @@ test('Count - values not an array', () => {
   const expression = { operator: 'length', values: 'Wrong' }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
     expect(result).toEqual(
-      'Operator: COUNT\n- Property "values" (value: "Wrong") is not of type: array'
+      'Operator: COUNT - Type Error\n- Property "values" (value: "Wrong") is not of type: array'
     )
   })
 })
@@ -367,7 +363,9 @@ test('Count - values not an array', () => {
 test('Count - missing values', () => {
   const expression = { operator: 'Count' }
   return exp.evaluate(expression, { returnErrorAsString: true }).then((result) => {
-    expect(result).toBe('Operator: COUNT\n- Missing required property "values" (type: array)')
+    expect(result).toBe(
+      'Operator: COUNT - Type Error\n- Missing required property "values" (type: array)'
+    )
   })
 })
 

--- a/test/6_conditional.test.ts
+++ b/test/6_conditional.test.ts
@@ -85,7 +85,7 @@ test('Conditional -- missing parameters', async () => {
     operator: '?',
   }
   await expect(evaluateExpression(expression)).rejects.toThrow(
-    'Operator: CONDITIONAL\n- Missing required property "condition" (type: any)\n- Missing required property "valueIfTrue" (type: any)\n- Missing required property "valueIfFalse" (type: any)'
+    '- Missing required property "condition" (type: any)\n- Missing required property "valueIfTrue" (type: any)\n- Missing required property "valueIfFalse" (type: any)'
   )
 })
 
@@ -97,7 +97,7 @@ test('Conditional -- 1 missing parameter (error as string)', () => {
   }
   return exp.evaluate(expression).then((result) => {
     expect(result).toBe(
-      'Operator: CONDITIONAL\n- Missing required property "valueIfTrue" (type: any)'
+      'Operator: CONDITIONAL - Type Error\n- Missing required property "valueIfTrue" (type: any)'
     )
   })
 })

--- a/test/9_stringSubstitution.test.ts
+++ b/test/9_stringSubstitution.test.ts
@@ -195,7 +195,7 @@ test('String substitution - parameters contain further expressions', () => {
 test('String substitution -- missing parameters', async () => {
   const expression = { operator: 'replace', irrelevant: 'value' }
   await expect(exp.evaluate(expression)).rejects.toThrow(
-    'Operator: STRING_SUBSTITUTION\n- Missing required property "string" (type: string)'
+    '- Missing required property "string" (type: string)'
   )
 })
 


### PR DESCRIPTION
Fix #113 

- Expose more error detail in a structured manner from internal processes (such as HTTP clients)
- More standardised string representations of errors (see `errorOrFallback` function)
- Standardised `FigTreeError` type for all errors (extends standard `Error` object)
- Update tests to reflect the above changes
- Update documentation with an "Error handling" section